### PR TITLE
add Firefox add-ons link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,10 @@
 
 ## Installation
 
-See https://developer.mozilla.org/en-US/docs/Tools/about:debugging#Add-ons for
-further information on how to load the extension.
+Install the add-on for Firefox:
+[Screensharing for Nextcloud Video calls app](https://addons.mozilla.org/firefox/addon/nextcloud-video-calls/)
+
+## Developer setup
+
+1. Clone this repository
+2. See https://developer.mozilla.org/en-US/docs/Tools/about:debugging#Add-ons for further information on how to load the extension.


### PR DESCRIPTION
Please review @nickvergessen @ivansss @fancycode, this is the same as for Chrome Webstore: https://github.com/nextcloud/spreed-screensharing-chrome-extension/pull/3